### PR TITLE
Use foreman to start the development server

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,0 +1,2 @@
+frontend: yarn dev
+backend: iex -S mix phx.server +BI

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,2 +1,2 @@
 frontend: yarn dev
-backend: iex -S mix phx.server +BI
+backend: mix phx.server

--- a/README.md
+++ b/README.md
@@ -1,5 +1,15 @@
 # PhoenixStarter
 
+A starter that combines Phoenix + Snowpack + React. (but you can use anything else, like Svelte, which is great)
+
+## Prerequisites
+
+- postgres - install via Homebrew or your preferred package manager
+- asdf-vm - [check their website](https://asdf-vm.com/#/core-manage-asdf)
+- foreman - `foreman` on Homebrew and `ruby-foreman` on Ubuntu
+
+## Getting Started
+
 To start your Phoenix app:
   * Install dependencies and setup database with `bin/setup`
   * Start Phoenix and webpack with `bin/server`

--- a/bin/server
+++ b/bin/server
@@ -4,8 +4,4 @@ set -e
 . "./bin/functions"
 test -f .envrc && . "./.envrc"
 
-pp_info "server" "Starting development server..."
-yarn dev&
-iex -S mix phx.server
-
-trap "trap - SIGTERM && kill -- -$$" SIGINT SIGTERM EXIT
+foreman start --procfile=Procfile.dev


### PR DESCRIPTION
Our `bin/server` script caused some formatting issues and was a bit brittle in regards to zombie node processed and the like. For example, if the `elixir` process crashed, the script would exit and you would have a zombie process (snowpack) even with the traps and the like. And it wasn't that cross platform.

Like our `rails-starter` we decided to use foreman. Both linux and mac users can easily install it.

This way you get a nice way of running both the snowpack dev server and iex without issues.