### PR TITLE
Fix crash when visiting sign up after error

### DIFF
--- a/frontend/src/components/Router.tsx
+++ b/frontend/src/components/Router.tsx
@@ -3,10 +3,10 @@ import { Switch, Route, Redirect, RouteProps } from "react-router-dom";
 import loadable from "@loadable/component";
 import useAuth from "root/hooks/useAuth";
 
-type AsyncRouteProps = RouteProps & { importPath: Promise<any> };
+type AsyncRouteProps = RouteProps & { importPath: () => Promise<any> };
 
-function AsyncRoute(props: AsyncRouteProps) {
-  return <Route {...props} component={loadable(() => props.importPath)} />;
+function AsyncRoute({ importPath, ...props }: AsyncRouteProps) {
+  return <Route {...props} component={loadable(importPath)} />;
 }
 
 function AuthenticatedRoute(props: AsyncRouteProps) {
@@ -23,17 +23,17 @@ export default function Router() {
       <AuthenticatedRoute
         exact
         path="/"
-        importPath={import("root/pages/HomePage")}
+        importPath={() => import("root/pages/HomePage")}
       />
       <AsyncRoute
         exact
         path="/login"
-        importPath={import("root/pages/LoginPage")}
+        importPath={() => import("root/pages/LoginPage")}
       />
       <AsyncRoute
         exact
         path="/sign_up"
-        importPath={import("root/pages/SignUpPage")}
+        importPath={() => import("root/pages/SignUpPage")}
       />
     </Switch>
   );

--- a/frontend/src/hooks/useAuth.tsx
+++ b/frontend/src/hooks/useAuth.tsx
@@ -6,7 +6,7 @@ import React, {
   useMemo,
   useState,
 } from "react";
-import { useHistory } from "react-router-dom";
+import { useHistory, useLocation } from "react-router-dom";
 import * as sessionsApi from "root/api/sessions";
 import * as usersApi from "root/api/users";
 
@@ -31,9 +31,15 @@ export function AuthProvider({
   const [loading, setLoading] = useState<boolean>(false);
   const [loadingInitial, setLoadingInitial] = useState<boolean>(true);
   const history = useHistory();
+  const location = useLocation();
 
   useEffect(() => {
-    usersApi.getCurrentUser()
+    if (error) setError(undefined);
+  }, [location.pathname]);
+
+  useEffect(() => {
+    usersApi
+      .getCurrentUser()
       .then((user) => setUser(user))
       .catch((_error) => {})
       .finally(() => setLoadingInitial(false));
@@ -42,7 +48,8 @@ export function AuthProvider({
   function login(email: string, password: string) {
     setLoading(true);
 
-    sessionsApi.login({ email, password })
+    sessionsApi
+      .login({ email, password })
       .then((user) => {
         setUser(user);
         history.push("/");
@@ -54,7 +61,8 @@ export function AuthProvider({
   function signUp(email: string, name: string, password: string) {
     setLoading(true);
 
-    usersApi.signUp({ email, name, password })
+    usersApi
+      .signUp({ email, name, password })
       .then((user) => {
         setUser(user);
         history.push("/");


### PR DESCRIPTION
After the **login** page gets an error, if you visit the sign up page you crash the app. This happens because the sign up page views the `error` state and tries to get validation errors from that, but the error is a login error, which is an empty response with 401 code.

This PR adds a fix so that whenever the route of the app changes, we reset the error state if it exists, to avoid extra renders.

This PR also fixes a issue with code splitting. The way we had it all the chunks were being evaluated at first. We just need to change the `importPath` prop to a function so it gets evaluated correctly by `loadable`.