### PR TITLE
Use new erlef/setup-elixir action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,6 @@ jobs:
       with:
         elixir-version: 1.11.3
         otp-version: 23.2.4
-        experimental-otp: true
 
     - name: Cache elixir deps
       uses: actions/cache@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Setup elixir
-      uses: actions/setup-elixir@v1
+      uses: erlef/setup-elixir@v1
       with:
         elixir-version: 1.11.3
         otp-version: 23.2.4


### PR DESCRIPTION
`actions/setup-elixir` is deprecated by Github and their recommendation is to use `erlef/setup-elixir` which is maintained by the erlang foundation.