### PR TITLE
Add support for MacOS to the `bin/rename`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,7 @@ phoenix_starter-*.tar
 npm-debug.log
 
 # The directory NPM downloads your dependencies sources to.
-/assets/node_modules/
+/frontend/node_modules/
 
 # Since we are building assets from assets/,
 # we ignore priv/static. You may want to comment

--- a/bin/rename
+++ b/bin/rename
@@ -11,8 +11,16 @@ read -r NEW_NAME
 echo "Please enter new OTP name (current: "$CURRENT_OTP")"
 read -r NEW_OTP
 
-git ls-tree -r master --name-only | xargs grep -I -l $CURRENT_NAME | xargs -r sed -i -e "s/$CURRENT_NAME/$NEW_NAME/g"
-git ls-tree -r master --name-only | xargs grep -I -l $CURRENT_OTP | xargs -r sed -i -e "s/$CURRENT_OTP/$NEW_OTP/g"
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+  git ls-tree -r master --name-only | xargs grep -I -l $CURRENT_NAME | xargs -r sed -i -e "s/$CURRENT_NAME/$NEW_NAME/g"
+  git ls-tree -r master --name-only | xargs grep -I -l $CURRENT_OTP | xargs -r sed -i -e "s/$CURRENT_OTP/$NEW_OTP/g"
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+  git ls-tree -r master --name-only | xargs grep -I -l $CURRENT_NAME | xargs sed -i '' "s/$CURRENT_NAME/$NEW_NAME/g"
+  git ls-tree -r master --name-only | xargs grep -I -l $CURRENT_OTP | xargs sed -i '' "s/$CURRENT_OTP/$NEW_OTP/g"
+else
+  echo "Unknown OS"
+  exit 1
+fi
 
 [ -d lib/$CURRENT_OTP ] && mv lib/$CURRENT_OTP lib/$NEW_OTP
 [ -f lib/$CURRENT_OTP.ex ] && mv lib/$CURRENT_OTP.ex lib/$NEW_OTP.ex


### PR DESCRIPTION
Why:
* The `bin/rename` script was misbehaving on MacOS as it was generating
  extra files with a `-e` extension due to the way `sed` works on MacOS
* [Relevant info](https://stackoverflow.com/questions/34533893/sed-command-creating-unwanted-duplicates-of-file-with-e-extension)

How:
* Checking for the OS type and running the `sed` command with the
  appropriate options to replace the contents of the files of the project
