### PR TITLE
Project setup updates

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -51,7 +51,8 @@ pp_info "setup" "Installing elixir dependencies..."
 MIX_ENV=$env mix local.hex --force
 MIX_ENV=$env mix local.rebar --force
 MIX_ENV=$env mix deps.get
-mix archive.install hex phx_new 1.4.8 --force
+MIX_ENV=$env mix archive.install hex phx_new 1.5.9 --force
+MIX_ENV=$env mix ecto.setup
 
 echo ""
 pp_info "setup" "Installing node dependencies..."

--- a/mix.exs
+++ b/mix.exs
@@ -30,7 +30,7 @@ defmodule PhoenixStarter.MixProject do
     [
       {:argon2_elixir, "~> 2.4"},
       {:cors_plug, "~> 2.0"},
-      {:phoenix, "~> 1.5.6"},
+      {:phoenix, "~> 1.5.9"},
       {:phoenix_pubsub, "~> 2.0.0"},
       {:phoenix_ecto, "~> 4.0"},
       {:ecto_sql, "~> 3.5"},


### PR DESCRIPTION
Why:
* Running `bin/setup` was not creating the local development database
* Updating the Phoenix version to the latest minor version, 1.5.9 in the
  `bin/setup`

How:
* Adding `mix ecto.setup` to the `bin/setup`
* `bin/setup` was installing the Phoenix generator for the `1.4.8`
  version while the dependency in the `mix.exs` was set to `1.5.6`
