### PR TITLE
Pass node options to `yarn build`

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -7,7 +7,7 @@ test -f .envrc && . "./.envrc"
 pp_info "build" "Building the frontend assets..."
 
 rm -rf frontend/build priv/static
-yarn build
+NODE_OPTIONS=--openssl-legacy-provider yarn build
 mkdir -p priv/static
 cp -R frontend/build/* priv/static
 rm -rf frontend/build


### PR DESCRIPTION
Why:
* Node version 18 no longer supports MD4 as a hashing algorithm
* Trying to build the project results in a `ERR_OSSL_EVP_UNSUPPORTED`
  error
* https://nodejs.org/api/cli.html#--openssl-legacy-provider
* https://stackoverflow.com/questions/69394632/webpack-build-failing-with-err-ossl-evp-unsupported

How:
* Adding `NODE_OPTIONS=--openssl-legacy-provider` to the `yarn build`
  command in `bin/build` script
